### PR TITLE
feat: add cstore hsync client

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,37 @@ const allFields = await ratio1.cstore.hgetall({
   hkey: 'user:123'
 })
 // Returns: { success: true, result: { keys: ['name', 'email', 'age'] } }
+
+// Refresh one hash namespace from live peer state
+const syncResult = await ratio1.cstore.hsync({
+  hkey: 'user:123'
+})
+// Returns: { hkey: 'user:123', source_peer: '0xpeer', merged_fields: 2 }
+```
+
+`hsync` is merge-only:
+
+- remote fields missing locally are added
+- overlapping stale local fields are overwritten
+- local-only fields are preserved
+
+An empty snapshot from a valid peer is still success and returns
+`merged_fields: 0`. Timeout means no valid peer responded.
+
+#### Boot-Time Refresh Example
+
+Apps that need peer state before serving traffic can drive `hsync` from their
+own startup environment contract:
+
+```typescript
+const hkeys = (process.env.APP_CSTORE_HSYNC_HKEYS ?? '')
+  .split(',')
+  .map((value) => value.trim())
+  .filter(Boolean)
+
+for (const hkey of hkeys) {
+  await ratio1.cstore.hsync({ hkey })
+}
 ```
 
 #### Advanced Usage Examples

--- a/src/__tests__/cstore.test.ts
+++ b/src/__tests__/cstore.test.ts
@@ -60,4 +60,33 @@ describe('cstore e2e', () => {
     const res = await client.cstore.hgetall({ hkey: 'e2e-hkey' })
     expect(res).toBeTruthy()
   })
+
+  it('hsync refreshes a hash namespace', async () => {
+    nock(cstoreBase)
+      .post('/hsync', { hkey: 'e2e-hkey', chainstore_peers: [] })
+      .reply(200, {
+        result: { hkey: 'e2e-hkey', source_peer: 'peer-a', merged_fields: 2 }
+      })
+
+    const res = await client.cstore.hsync({ hkey: 'e2e-hkey' })
+    expect(res).toEqual({ hkey: 'e2e-hkey', source_peer: 'peer-a', merged_fields: 2 })
+  })
+
+  it('hsyncFull returns the full response envelope', async () => {
+    nock(cstoreBase)
+      .post('/hsync', { hkey: 'e2e-hkey', chainstore_peers: [] })
+      .reply(200, {
+        result: { hkey: 'e2e-hkey', source_peer: 'peer-a', merged_fields: 0 },
+        ee_node_alias: 'node'
+      })
+
+    const res = await client.cstore.hsyncFull({ hkey: 'e2e-hkey' })
+    expect(res.result).toEqual({ hkey: 'e2e-hkey', source_peer: 'peer-a', merged_fields: 0 })
+    expect(res.ee_node_alias).toBe('node')
+  })
+
+  it('hsync validates that hkey is required', async () => {
+    await expect(client.cstore.hsync({ hkey: '' })).rejects.toThrow('hkey is required')
+    await expect(client.cstore.hsyncFull({ hkey: '' })).rejects.toThrow('hkey is required')
+  })
 })

--- a/src/__tests__/cstoreClient.test.ts
+++ b/src/__tests__/cstoreClient.test.ts
@@ -23,4 +23,22 @@ describe('CStoreClient', () => {
     const res = await ratio1.cstore.hgetall({ hkey: 'test' })
     expect(res).toBeDefined()
   })
+
+  it('hsync posts to the hsync endpoint with configured chainstore peers', async () => {
+    const ratio1 = createEdgeSdk({
+      cstoreUrl: baseUrl,
+      r1fsUrl: 'http://localhost:31235',
+      chainstorePeers: ['peer-a', 'peer-b'],
+      httpAdapter: { fetch: crossFetch as any }
+    })
+
+    nock(baseUrl)
+      .post('/hsync', { hkey: 'players', chainstore_peers: ['peer-a', 'peer-b'] })
+      .reply(200, {
+        result: { hkey: 'players', source_peer: 'peer-a', merged_fields: 2 }
+      })
+
+    const res = await ratio1.cstore.hsync({ hkey: 'players' })
+    expect(res).toEqual({ hkey: 'players', source_peer: 'peer-a', merged_fields: 2 })
+  })
 })

--- a/src/cstore/httpClient.ts
+++ b/src/cstore/httpClient.ts
@@ -9,6 +9,8 @@ import {
   type CStoreHGetResult,
   type CStoreHSetResponse,
   type CStoreHSetResult,
+  type CStoreHSyncResponse,
+  type CStoreHSyncResult,
   type CStoreSetResponse,
   type CStoreSetResult,
   type CStoreStatusResponse,
@@ -17,6 +19,7 @@ import {
   type HGetAllRequest,
   type HGetRequest,
   type HSetRequest,
+  type HSyncRequest,
   type SetValueRequest
 } from './types'
 
@@ -112,6 +115,24 @@ export class CStoreHttpClient extends BaseHttpClient {
     const qs = this.buildQuery({ hkey: request.hkey })
     const res = await this.request(`/hgetall?${qs}`, { method: 'GET' })
     return await this.parseResponseFull<CStoreHGetAllResult<T>, CStoreHGetAllResponse<T>>(res)
+  }
+
+  async hsync(request: HSyncRequest): Promise<CStoreHSyncResult> {
+    const res = await this.hsyncFull(request)
+    return res.result
+  }
+
+  async hsyncFull(request: HSyncRequest): Promise<CStoreHSyncResponse> {
+    const chainstorePeers = this.resolveChainstorePeers()
+    const res = await this.request('/hsync', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        hkey: request.hkey,
+        chainstore_peers: chainstorePeers
+      })
+    })
+    return await this.parseResponseFull<CStoreHSyncResult, CStoreHSyncResponse>(res)
   }
 
   private resolveChainstorePeers(): string[] {

--- a/src/cstore/service.ts
+++ b/src/cstore/service.ts
@@ -8,6 +8,8 @@ import type {
   CStoreHGetResult,
   CStoreHSetResponse,
   CStoreHSetResult,
+  CStoreHSyncResponse,
+  CStoreHSyncResult,
   CStoreSetResponse,
   CStoreSetResult,
   CStoreStatusResponse,
@@ -16,6 +18,7 @@ import type {
   HGetAllRequest,
   HGetRequest,
   HSetRequest,
+  HSyncRequest,
   SetValueRequest
 } from './types'
 
@@ -86,5 +89,15 @@ export class CStoreService {
   async hgetallFull<T = unknown>(data: HGetAllRequest): Promise<CStoreHGetAllResponse<T>> {
     if (data.hkey === '') throw new Error('hkey is required')
     return await this.http.hgetallFull<T>(data)
+  }
+
+  async hsync(data: HSyncRequest): Promise<CStoreHSyncResult> {
+    if (data.hkey === '') throw new Error('hkey is required')
+    return await this.http.hsync(data)
+  }
+
+  async hsyncFull(data: HSyncRequest): Promise<CStoreHSyncResponse> {
+    if (data.hkey === '') throw new Error('hkey is required')
+    return await this.http.hsyncFull(data)
   }
 }

--- a/src/cstore/types/index.ts
+++ b/src/cstore/types/index.ts
@@ -13,6 +13,12 @@ export type CStoreSetResult = boolean
 
 export type CStoreHSetResult = boolean
 
+export interface CStoreHSyncResult {
+  hkey: string
+  source_peer: string | null
+  merged_fields: number
+}
+
 export type CStoreHGetResult<T = unknown> = T
 
 export type CStoreHGetAllResult<T = unknown> = Record<string, T>
@@ -33,6 +39,8 @@ export interface CStoreGetResponse<T = unknown> extends CStoreBaseResponse<CStor
 export interface CStoreSetResponse extends CStoreBaseResponse<CStoreSetResult> {}
 
 export interface CStoreHSetResponse extends CStoreBaseResponse<CStoreHSetResult> {}
+
+export interface CStoreHSyncResponse extends CStoreBaseResponse<CStoreHSyncResult> {}
 
 export interface CStoreHGetResponse<T = unknown> extends CStoreBaseResponse<CStoreHGetResult<T>> {}
 
@@ -60,6 +68,10 @@ export interface HSetRequest {
 export interface HGetRequest {
   hkey: string
   key: string
+}
+
+export interface HSyncRequest {
+  hkey: string
 }
 
 export interface HGetAllRequest {


### PR DESCRIPTION
## Summary
- add `cstore.hsync(...)` and `cstore.hsyncFull(...)`
- send the new request to `POST /hsync` with resolved `chainstore_peers`
- add typed `CStoreHSyncResult` / `CStoreHSyncResponse` support
- document merge-only behavior and a boot-time env-driven startup pattern in the README

## Verification
- pass: `npm test -- --runInBand src/__tests__/cstoreClient.test.ts src/__tests__/cstore.test.ts`
- pass: `npm run build`

## Dependency
- pairs with `Ratio1/naeural_core` PR #197 and `Ratio1/edge_node` PR #389

## Notes
- the SDK surface is intentionally narrow: one request shape, one result shape, and no automatic startup orchestration